### PR TITLE
feat(export): export all status

### DIFF
--- a/lib/exporter.js
+++ b/lib/exporter.js
@@ -115,9 +115,12 @@ async function exportBook(parentDir, book, opts = {}) {
   const db = inkdrop.main.dataStore.getLocalDB()
   const dirName = sanitize(book.name, { replacement: '-' })
   const pathToSave = createBookDir ? path.join(parentDir, dirName) : parentDir
-  const { docs: notes } = await db.notes.findInBook(book._id, {
-    limit: false
-  })
+  const notes = (await db.notes.db.allDocs({
+    include_docs: true,
+    attachments: false,
+    startkey: "note:",
+    endkey: "note:￿",
+  })).rows.filter((row) => row.doc.bookId == book._id).map((row) => row.doc)
 
   !fs.existsSync(pathToSave) && fs.mkdirSync(pathToSave)
   for (let i = 0; i < notes.length; ++i) {

--- a/lib/exporter.js
+++ b/lib/exporter.js
@@ -115,12 +115,7 @@ async function exportBook(parentDir, book, opts = {}) {
   const db = inkdrop.main.dataStore.getLocalDB()
   const dirName = sanitize(book.name, { replacement: '-' })
   const pathToSave = createBookDir ? path.join(parentDir, dirName) : parentDir
-  const notes = (await db.notes.db.allDocs({
-    include_docs: true,
-    attachments: false,
-    startkey: "note:",
-    endkey: "note:￿",
-  })).rows.filter((row) => row.doc.bookId == book._id).map((row) => row.doc)
+  const notes = await db.notes.searchWithQuery([{ type: 'field', field: 'book', id: book._id }], { limit: 9999 })
 
   !fs.existsSync(pathToSave) && fs.mkdirSync(pathToSave)
   for (let i = 0; i < notes.length; ++i) {


### PR DESCRIPTION
Potentially closes #6 

Hi,
Since this functionality has become important to me, I have made a small change so that even normally invisible notes (status "completed" or "dropped") are exported. 

Unfortunately, I have not found a better way than simply loading all notes from the database and then checking if the note is in the correct notebook. As far as I have been able to tell, it is currently not possible to do this via the "_design/index_notes" view.

I am open to suggestions for a better solution.